### PR TITLE
Changed the signature page to not do a seprate query for each cell

### DIFF
--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -40,6 +40,17 @@ class SignaturesController < ApplicationController
       end
 
       @freshmen_on_packet = Freshman.where(on_packet: true).order(name: :asc)
+      f_ids = []
+      @freshmen.each {|f| f_ids << f.id }
+      @upperclass_signatures = Hash.new
+      @freshmen_signatures = Hash.new
+      Signature.where(freshman_id: f_ids).each do |s|
+          if s.signer_type == "Upperclassman"
+              @upperclass_signatures[[s.signer_id, s.freshman_id]] = s
+          else
+              @freshmen_signatures[[s.signer_id, s.freshman_id]] = s
+          end
+      end
     elsif freshman_signed_in?
       # Define title
       @title = "CSH Packet"

--- a/app/views/signatures/index.html.erb
+++ b/app/views/signatures/index.html.erb
@@ -23,7 +23,7 @@
         <tr>
           <th><%= link_to "#{u.name}", upperclassman_path(u.id) %></th>
           <% @freshmen.each do |f| %>
-            <% if Signature.exists?(freshman_id: f.id, signer_id: u.id, signer_type: "Upperclassman") %>
+            <% if @upperclass_signatures[[u.id, f.id]] != nil %>
               <td class="success"><span class="glyphicon glyphicon-ok"></span></td>  
             <% else %>
               <td><span class="glyphicon glyphicon-remove"></span></td>
@@ -52,7 +52,7 @@
         <tr>
           <th><%= link_to "#{fop.name}", freshman_path(fop.id) %></th>
           <% @freshmen.each do |f| %>
-            <% if Signature.exists?(freshman_id: f.id, signer_id: fop.id, signer_type: "Freshman") %>
+            <% if @freshmen_signatures[[fop.id, f.id]] != nil %>
               <td class="success"><span class="glyphicon glyphicon-ok"></span></td>  
             <% else %>
               <td><span class="glyphicon glyphicon-remove"></span></td>


### PR DESCRIPTION
Now one query is done and then parsed in memory instead. This yields a
significant decrease in latency a lot less load on the database. This should help you decrease the grid page's latency. A extra feature that might help as well is to use a enum instead of the strings "Upperclassman" and "Freshman".
